### PR TITLE
feat: Add plugin id to `plugins list` command for installation purposes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@makerkit/cli",
-  "version": "1.2.4",
+  "version": "1.2.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@makerkit/cli",
-      "version": "1.2.4",
+      "version": "1.2.10",
       "license": "ISC",
       "dependencies": {
         "@types/fs-extra": "^11.0.1",

--- a/src/commands/plugins/list/list-plugins.command.ts
+++ b/src/commands/plugins/list/list-plugins.command.ts
@@ -10,6 +10,11 @@ export function createListPluginsCommand(parentCommand: Command) {
     .action(() => {
       const kits = Object.values(KitsModel);
 
+      console.log(chalk.white('Makerkit available plugins...'));
+      console.log(
+        `[${chalk.green('Plugin Name')} (${chalk.gray('plugin-id')})]\n`
+      );
+
       for (const kit of kits) {
         console.log(`${chalk.cyan(kit.name)}`);
 
@@ -20,8 +25,8 @@ export function createListPluginsCommand(parentCommand: Command) {
         }
 
         for (const plugin of kit.plugins) {
-          const { name } = validatePlugin(plugin);
-          console.log(`- ${chalk.green(name)}`);
+          const { name, id } = validatePlugin(plugin);
+          console.log(`- ${chalk.green(name)} (${chalk.gray(id)})`);
         }
 
         console.log('');


### PR DESCRIPTION
Here is what the new output looks like:

<img width="326" alt="makerkit-cli-plugins-list" src="https://github.com/makerkit/cli/assets/129192050/49672c64-e51d-488f-a673-4b65a0dc0713">
