### PR TITLE
Make paddle and signoz plugins visible

### DIFF
--- a/src/kits-model.ts
+++ b/src/kits-model.ts
@@ -44,6 +44,8 @@ export const KitsModel = {
       PluginsModel.GoogleAnalytics.id,
       PluginsModel.Posthog.id,
       PluginsModel.Umami.id,
+      PluginsModel.Signoz.id,
+      PluginsModel.Paddle.id,
     ],
   },
   RemixSupabaseTurbo: {


### PR DESCRIPTION
To enable installation of the **Signoz** and **Paddle** plugins via CLI:
Currently, these plugins are not visible when running `npx @makerkit/cli@latest plugins install`.
After this change, the plugins will appear and be available for installation.